### PR TITLE
create a lib/ directory

### DIFF
--- a/lib/placeholder.txt
+++ b/lib/placeholder.txt
@@ -1,0 +1,3 @@
+We:
+- commit this file in order for git to create a lib/ directory, and
+- want a lib/ directory so pub will create a well-formed .packages file

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ name: cupertino_icons
 description: Default icons asset for Cupertino widgets
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/cupertino_icons
-version: 0.1.1
+version: 0.1.2
 
 flutter:
   fonts:


### PR DESCRIPTION
- commit a small file into `lib/` in order for git to create a lib/ directory

this will then make the .packages file that pub creates reference valid files paths, and will make tooling (like IntelliJ) happier - user's projects won't open with errors:

<img width="630" alt="screen shot 2018-04-03 at 8 44 47 pm" src="https://user-images.githubusercontent.com/1269969/38288049-f2a46a78-3782-11e8-9b3e-61dccaecf690.png">


<img width="607" alt="screen shot 2018-04-03 at 8 44 54 pm" src="https://user-images.githubusercontent.com/1269969/38288053-f7ba84a2-3782-11e8-9738-780f2a51e366.png">

@xster 